### PR TITLE
fix: Fixes issue with robot not responding to motor commands

### DIFF
--- a/src/engine/objects/robot/SimRobotWheel.ts
+++ b/src/engine/objects/robot/SimRobotWheel.ts
@@ -76,8 +76,10 @@ export class SimRobotWheel extends SimObject {
 
     const bodyCenter = this._body.getWorldCenter();
 
-    // Apply the force, simulating the wheel pushing against ground friction
-    this._body.applyForce(forceVector, bodyCenter);
+    if (forceVector.lengthSquared() > 0.001) {
+      // Apply the force, simulating the wheel pushing against ground friction
+      this._body.applyForce(forceVector, bodyCenter, true);
+    }
 
     // Update the mesh
     this._mesh.position.x = bodyCenter.x;


### PR DESCRIPTION
When a force is applied to the `SimRobotWheel` after some time of no
activity, the wheel body goes to sleep. the `applyForce()` method on it
has an optional 3rd parameter to wake the body up, which will then
actually apply the force.

Additionally, we also check and make sure that this is a sufficient
enough force to overcome static friction before moving.

Resolves #67 