### PR TITLE
feat: Properly reset simulator

### DIFF
--- a/src/engine/EventRegistry.ts
+++ b/src/engine/EventRegistry.ts
@@ -41,6 +41,7 @@ export class EventRegistry {
   private _world: World;
 
   private _timeSinceLastUpdate = 0;
+  private _onDispose: () => void;
 
   /**
    * Create a new EventRegistry and connect it to the provided world
@@ -49,10 +50,25 @@ export class EventRegistry {
   constructor(world: World) {
     // Hook up the event listeners for the physics engine
     // This is for collisions
-    world.on("begin-contact", this.onBeginContact.bind(this));
-    world.on("end-contact", this.onEndContact.bind(this));
+    const onBeginContantFunc: (
+      contact: Contact
+    ) => void = this.onBeginContact.bind(this);
+    const onEndContantFunc: (contact: Contact) => void = this.onEndContact.bind(
+      this
+    );
+    world.on("begin-contact", onBeginContantFunc);
+    world.on("end-contact", onEndContantFunc);
+
+    this._onDispose = () => {
+      world.off("begin-contact", onBeginContantFunc);
+      world.off("end-contact", onEndContantFunc);
+    };
 
     this._world = world;
+  }
+
+  dispose(): void {
+    this._onDispose();
   }
 
   // World event handlers

--- a/src/engine/HandleRegistry.ts
+++ b/src/engine/HandleRegistry.ts
@@ -1,0 +1,33 @@
+export class HandleRegistry {
+  private _invalidationCallbacks: Map<string, () => void> = new Map<
+    string,
+    () => void
+  >();
+
+  registerHandle(objectGuid: string, invalidateCb: () => void): void {
+    this._invalidationCallbacks.set(objectGuid, invalidateCb);
+  }
+
+  invalidateHandle(guid: string): void {
+    if (this._invalidationCallbacks.has(guid)) {
+      const invalidationCb = this._invalidationCallbacks.get(guid);
+      invalidationCb();
+    }
+  }
+
+  deleteHandle(guid: string): void {
+    this.invalidateHandle(guid);
+    this._invalidationCallbacks.delete(guid);
+  }
+
+  invalidateAllHandles(): void {
+    this._invalidationCallbacks.forEach((invalidationCb) => {
+      invalidationCb();
+    });
+  }
+
+  deleteAllHandles(): void {
+    this.invalidateAllHandles();
+    this._invalidationCallbacks.clear();
+  }
+}

--- a/src/engine/Sim3D.ts
+++ b/src/engine/Sim3D.ts
@@ -26,6 +26,7 @@ import { SimRobot } from "./objects/robot/SimRobot";
 import { RobotHandle } from "./handles/RobotHandle";
 import { EventRegistry } from "./EventRegistry";
 import { generateDebugGeometry } from "./utils/PhysicsDebug";
+import { HandleRegistry } from "./HandleRegistry";
 
 interface ISimObjectContainer {
   type: string;
@@ -64,6 +65,9 @@ export class Sim3D {
   private simObjects: Map<string, ISimObjectContainer>;
   private objectFactories: ObjectFactories;
 
+  // Handle registry
+  private handleRegistry: HandleRegistry;
+
   // Physics!
   private world: World;
 
@@ -79,37 +83,228 @@ export class Sim3D {
 
     this.config = config;
 
-    // SimObject registry
+    this.resetSimulator();
+  }
+
+  // Public API - Core
+  /**
+   * Configure the world
+   *
+   * This essentially means reset the simulator environment, and add the playing field (and walls if necessary)
+   * @param worldConfig Configuration for the world
+   */
+  configureWorld(worldConfig: WorldConfig): void {
+    this.config.defaultWorld = worldConfig;
+    this.resetSimulator();
+  }
+
+  /**
+   * Reset the entire simulator and reload from configuration
+   *
+   * This method performs a clean-slate wipe of the simulator, removing all
+   * 3D objects from the scene, all physics bodies as well as invalidating
+   * any existing object handles. It then recreates the scene as provided
+   * either in the initial configuration, or as specified via {@link configureWorld}.
+   *
+   * Calling this method will result in all previously added objects being removed
+   * from the scene, and they will need to be re-added.
+   */
+  resetSimulator(): void {
+    this.resetSceneAndWorld();
+    this.initSceneAndWorld();
+  }
+
+  /**
+   * Trigger a recalculation of the scene when resized
+   */
+  onresize(): void {
+    this.camera.aspect = this.canvas.width / this.canvas.height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(this.canvas.width, this.canvas.height);
+  }
+
+  /**
+   * Start the simulation
+   */
+  beginRendering(): void {
+    const r = (time: number) => {
+      if (!this.isRendering) {
+        return;
+      }
+
+      // dt here is in seconds
+      const dt = (time - this.lastAnimateTime) / 1000;
+      this.lastAnimateTime = time;
+
+      window.requestAnimationFrame(r);
+      this.updatePhysics(dt);
+      this.eventRegistry.update(dt);
+      this.render();
+    };
+
+    this.isRendering = true;
+    window.requestAnimationFrame(r);
+  }
+
+  /**
+   * Stop the simulation
+   */
+  stopRendering(): void {
+    this.isRendering = false;
+  }
+
+  // Public API - Objects
+  /**
+   * Add a new Ball object to the simulation
+   * @param spec Specification for a Ball
+   */
+  addBall(spec: IBallSpec): BallHandle | undefined {
+    return this.addGameObject<BallHandle>(spec, BallHandle);
+  }
+
+  /**
+   * Add a new Box object to the simulation
+   * @param spec Specification for a Box
+   */
+  addBox(spec: IBoxSpec): BoxHandle | undefined {
+    return this.addGameObject<BoxHandle>(spec, BoxHandle);
+  }
+
+  /**
+   * Add a new Wall to the simulation
+   * @param spec Specification for a Wall
+   */
+  addWall(spec: IWallSpec): WallHandle | undefined {
+    return this.addGameObject<WallHandle>(spec, WallHandle);
+  }
+
+  /**
+   * Add a new Pyramid to the simulation
+   * @param spec Specification for a Pyramid
+   */
+  addPyramid(spec: IPyramidSpec): PyramidHandle | undefined {
+    return this.addGameObject<PyramidHandle>(spec, PyramidHandle);
+  }
+
+  /**
+   * Add a new Cone to the simulation
+   * @param spec Specification for a Cone
+   */
+  addCone(spec: IConeSpec): ConeHandle | undefined {
+    return this.addGameObject<ConeHandle>(spec, ConeHandle);
+  }
+
+  /**
+   * Add a new Cylinder to the simulation
+   * @param spec Specification for a Cylinder
+   */
+  addCylinder(spec: ICylinderSpec): CylinderHandle | undefined {
+    return this.addGameObject<CylinderHandle>(spec, CylinderHandle);
+  }
+
+  /**
+   * Add a new, controllable robot to the simulation
+   * @param spec Specification for a robot
+   */
+  addRobot(spec: IRobotSpec): RobotHandle | undefined {
+    const robot = new SimRobot(spec);
+
+    const robotBody = this.world.createBody(robot.getBodySpecs());
+    robot.setBody(robotBody);
+    robotBody.createFixture(robot.getFixtureDef());
+
+    // Create bodies and fixtures for the children
+    robot.children.forEach((child) => {
+      const childBody = this.world.createBody(child.getBodySpecs());
+      child.setBody(childBody);
+      childBody.createFixture(child.getFixtureDef());
+    });
+
+    // Tell the robot to configure the joints appropriately
+    robot.configureFixtureLinks(this.world);
+
+    // Register with the event system
+    robot.registerWithEventSystem(this.eventRegistry);
+
+    this.addToScene(robot);
+    this.simObjects.set(robot.guid, {
+      type: robot.type,
+      object: robot,
+    });
+
+    const simObjectRef = {
+      guid: robot.guid,
+      type: robot.type,
+    };
+
+    const robotRoot = (this.getSimObject(simObjectRef) as unknown) as SimRobot;
+    if (!robotRoot) {
+      throw new Error(
+        `Unable to get SimObject with guid "${simObjectRef.guid}"`
+      );
+    }
+
+    const handle = new RobotHandle(robot, robotRoot, this.handleRegistry);
+    return handle;
+  }
+
+  isDebugMode() {
+    return this.debugMesh.visible;
+  }
+
+  setDebugMode(enabled: boolean) {
+    this.debugMesh.visible = enabled;
+  }
+
+  /**
+   * Destroy and recreate the 3D scene and physics world
+   */
+  private resetSceneAndWorld(): void {
+    if (this.scene) {
+      // Delete all items from the scene
+      while (this.scene.children.length > 0) {
+        this.scene.remove(this.scene.children[0]);
+      }
+    } else {
+      this.scene = new THREE.Scene();
+      this.scene.background = new THREE.Color(0xeeeeee);
+    }
+
+    if (!this.renderer) {
+      this.renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        canvas: this.canvas,
+      });
+    }
+
+    if (this.handleRegistry) {
+      // Invalidate and delete all handles
+      this.handleRegistry.deleteAllHandles();
+    } else {
+      this.handleRegistry = new HandleRegistry();
+    }
+
+    if (this.simObjects) {
+      this.simObjects.clear();
+      this.simObjects = undefined;
+    }
+
     this.simObjects = new Map<string, ISimObjectContainer>();
 
-    // Physics Setup
-    const gravity = new Vec2(0, 0);
-    this.world = new World(gravity);
+    // Dispose the event registry
+    if (this.eventRegistry) {
+      this.eventRegistry.dispose();
+      this.eventRegistry = undefined;
+    }
 
-    // Scene
-    const scene = (this.scene = new THREE.Scene());
-    scene.background = new THREE.Color(0xeeeeee);
+    // Recreate the world
+    this.world = new World(new Vec2(0, 0));
 
-    // Renderer
-    const renderer = (this.renderer = new THREE.WebGLRenderer({
-      antialias: true,
-      canvas: canvas,
-    }));
-    renderer.setSize(canvas.width, canvas.height);
-
-    // Set up our object factories
+    // Recreate object factories
     this.objectFactories = new ObjectFactories(this.scene, this.world);
 
-    // Set up the Event Registry
+    // Recreate Event registry
     this.eventRegistry = new EventRegistry(this.world);
-
-    // If a default world is specified, configure it now
-    // The reset method runs when configureWorld is called
-    this.configureWorld(config.defaultWorld);
-
-    // Axes
-    const axesHelper = new THREE.AxesHelper(1);
-    scene.add(axesHelper);
 
     // Debug
     const emptyGeometry = new THREE.Geometry();
@@ -118,15 +313,16 @@ export class Sim3D {
     debugMaterial.wireframe = true;
     this.debugMesh = new THREE.Mesh(emptyGeometry, debugMaterial);
     this.debugMesh.visible = false;
-    scene.add(this.debugMesh);
+    this.scene.add(this.debugMesh);
   }
 
-  private resetScene(config: WorldConfig) {
-    while (this.scene.children.length > 0) {
-      this.scene.remove(this.scene.children[0]);
-    }
+  /**
+   * Initializes the basic scene using the `defaultWorld` in config
+   */
+  private initSceneAndWorld(): void {
+    const worldConfig = this.config.defaultWorld;
 
-    // Camera
+    // Set up the lights and camera
     const fov = 80;
     const aspect = this.canvas.width / this.canvas.height;
     const near = 0.01;
@@ -138,8 +334,8 @@ export class Sim3D {
       far
     ));
 
-    camera.position.z += config.camera ? config.camera.position.z : 0;
-    camera.position.y += config.camera ? config.camera.position.y : 0;
+    camera.position.z += worldConfig.camera ? worldConfig.camera.position.z : 0;
+    camera.position.y += worldConfig.camera ? worldConfig.camera.position.y : 0;
     this.cameraControls = new OrbitControls(camera, this.renderer.domElement);
 
     // Lighting
@@ -150,16 +346,6 @@ export class Sim3D {
     this.scene.add(pointLight);
 
     this.scene.add(new THREE.AmbientLight(0x333333));
-  }
-
-  /**
-   * Configure the world
-   *
-   * This essentially means reset the simulator environment, and add the playing field (and walls if necessary)
-   * @param worldConfig Configuration for the world
-   */
-  configureWorld(worldConfig: WorldConfig): void {
-    this.resetScene(worldConfig);
 
     // Grid - By default, draw grid lines every 1 unit (metre)
     const grid = makeGrid(
@@ -203,15 +389,13 @@ export class Sim3D {
         });
       }
     }
+
+    // Axes
+    const axesHelper = new THREE.AxesHelper(1);
+    this.scene.add(axesHelper);
   }
 
-  onresize(): void {
-    this.camera.aspect = this.canvas.width / this.canvas.height;
-    this.camera.updateProjectionMatrix();
-    this.renderer.setSize(this.canvas.width, this.canvas.height);
-  }
-
-  render(): void {
+  private render(): void {
     this.cameraControls.update();
     if (this.debugMesh.visible) {
       this.debugMesh.geometry = new THREE.Geometry();
@@ -220,7 +404,7 @@ export class Sim3D {
     this.renderer.render(this.scene, this.camera);
   }
 
-  updatePhysics(time: number): void {
+  private updatePhysics(time: number): void {
     this.simObjects.forEach((simObject) => {
       simObject.object.update(time);
     });
@@ -228,32 +412,8 @@ export class Sim3D {
     this.world.clearForces();
   }
 
-  beginRendering(): void {
-    const r = (time: number) => {
-      if (!this.isRendering) {
-        return;
-      }
-
-      // dt here is in seconds
-      const dt = (time - this.lastAnimateTime) / 1000;
-      this.lastAnimateTime = time;
-
-      window.requestAnimationFrame(r);
-      this.updatePhysics(dt);
-      this.eventRegistry.update(dt);
-      this.render();
-    };
-
-    this.isRendering = true;
-    window.requestAnimationFrame(r);
-  }
-
-  stopRendering(): void {
-    this.isRendering = false;
-  }
-
   // Sim Object methods
-  getSimObject(ref: ISimObjectRef): SimObject | undefined {
+  private getSimObject(ref: ISimObjectRef): SimObject | undefined {
     if (!this.simObjects.has(ref.guid)) {
       return undefined;
     }
@@ -268,7 +428,13 @@ export class Sim3D {
 
   private addGameObject<T1>(
     spec: SimObjectSpec,
-    typeT: { new (simObject: SimObject, rootObject: SimObject): T1 }
+    typeT: {
+      new (
+        simObject: SimObject,
+        rootObject: SimObject,
+        handleRegistry: HandleRegistry
+      ): T1;
+    }
   ): T1 | undefined {
     const obj = this.objectFactories.makeObject(spec);
     if (obj === undefined) {
@@ -298,32 +464,8 @@ export class Sim3D {
       );
     }
 
-    const handle = new typeT(obj, rootObject);
+    const handle = new typeT(obj, rootObject, this.handleRegistry);
     return handle;
-  }
-
-  addBall(spec: IBallSpec): BallHandle | undefined {
-    return this.addGameObject<BallHandle>(spec, BallHandle);
-  }
-
-  addBox(spec: IBoxSpec): BoxHandle | undefined {
-    return this.addGameObject<BoxHandle>(spec, BoxHandle);
-  }
-
-  addWall(spec: IWallSpec): WallHandle | undefined {
-    return this.addGameObject<WallHandle>(spec, WallHandle);
-  }
-
-  addPyramid(spec: IPyramidSpec): PyramidHandle | undefined {
-    return this.addGameObject<PyramidHandle>(spec, PyramidHandle);
-  }
-
-  addCone(spec: IConeSpec): ConeHandle | undefined {
-    return this.addGameObject<ConeHandle>(spec, ConeHandle);
-  }
-
-  addCylinder(spec: ICylinderSpec): CylinderHandle | undefined {
-    return this.addGameObject<CylinderHandle>(spec, CylinderHandle);
   }
 
   /**
@@ -334,55 +476,5 @@ export class Sim3D {
     simObject.children.forEach((simObj) => {
       this.addToScene(simObj);
     });
-  }
-
-  addRobot(spec: IRobotSpec): RobotHandle | undefined {
-    const robot = new SimRobot(spec);
-
-    const robotBody = this.world.createBody(robot.getBodySpecs());
-    robot.setBody(robotBody);
-    robotBody.createFixture(robot.getFixtureDef());
-
-    // Create bodies and fixtures for the children
-    robot.children.forEach((child) => {
-      const childBody = this.world.createBody(child.getBodySpecs());
-      child.setBody(childBody);
-      childBody.createFixture(child.getFixtureDef());
-    });
-
-    // Tell the robot to configure the joints appropriately
-    robot.configureFixtureLinks(this.world);
-
-    // Register with the event system
-    robot.registerWithEventSystem(this.eventRegistry);
-
-    this.addToScene(robot);
-    this.simObjects.set(robot.guid, {
-      type: robot.type,
-      object: robot,
-    });
-
-    const simObjectRef = {
-      guid: robot.guid,
-      type: robot.type,
-    };
-
-    const robotRoot = (this.getSimObject(simObjectRef) as unknown) as SimRobot;
-    if (!robotRoot) {
-      throw new Error(
-        `Unable to get SimObject with guid "${simObjectRef.guid}"`
-      );
-    }
-
-    const handle = new RobotHandle(robot, robotRoot);
-    return handle;
-  }
-
-  isDebugMode(): boolean {
-    return this.debugMesh.visible;
-  }
-
-  setDebugMode(enabled: boolean): void {
-    this.debugMesh.visible = enabled;
   }
 }

--- a/src/engine/handles/ObjectHandle.ts
+++ b/src/engine/handles/ObjectHandle.ts
@@ -1,12 +1,43 @@
 import { ISimObjectRef } from "../SimTypes";
 import { SimObject } from "../objects/SimObject";
+import { HandleRegistry } from "../HandleRegistry";
 
 export abstract class ObjectHandle<T extends SimObject> {
   protected _rootObject: T;
   protected _objectRef: ISimObjectRef;
+  protected _isValid: boolean;
 
-  constructor(ref: ISimObjectRef, rootObject: T) {
+  constructor(
+    ref: ISimObjectRef,
+    rootObject: T,
+    handleRegistry: HandleRegistry
+  ) {
     this._objectRef = ref;
     this._rootObject = rootObject;
+    this._isValid = true;
+
+    // Register ourselves with the handle registry
+    handleRegistry.registerHandle(
+      this._objectRef.guid,
+      this._onInvalidate.bind(this)
+    );
+  }
+
+  /**
+   * Whether or not this handle is currently valid
+   */
+  get valid(): boolean {
+    return this._isValid;
+  }
+
+  private _onInvalidate(): void {
+    // This method will get called when the handle is invalidated
+    // Basically we just set all our properties to undefined, and this will
+    // automatically throw whenever an external caller tries to invoke
+    // methods on the handle
+    this._rootObject = undefined;
+    this._objectRef = undefined;
+
+    this._isValid = false;
   }
 }


### PR DESCRIPTION
This commit provides the ability to properly reset the simulator
(including invalidating all existing handles). This allows scenes to be
re-created at any point.

Resolves #74 