### PR TITLE
added polygon and ellipse shaped zones

### DIFF
--- a/src/demos/demo1.ts
+++ b/src/demos/demo1.ts
@@ -226,8 +226,16 @@ function main() {
     initialPosition: { x: 0, y: 0 },
     baseColor: 0xff0000,
     opacity: 0.4,
-    xLength: 2,
-    zLength: 1,
+    //rectangleZone: {xLength: 2, zLength: 1,},
+    //ellipseZone: {xRadius: 1, zRadius: 2,},
+    polygonZone: {
+      points: [
+        { x: 0, y: 2 },
+        { x: 2, y: 2 },
+        { x: 2, y: 0 },
+        { x: 0, y: 0 },
+      ],
+    },
     zoneId: "test-zone",
   });
 

--- a/src/demos/demo1.ts
+++ b/src/demos/demo1.ts
@@ -221,21 +221,22 @@ function main() {
   };
   const robot = simulator.addRobot(spec);
 
+  const polygonZone = {
+    type: "polygon",
+    points: [
+      { x: 0, y: 2 },
+      { x: 2, y: 2 },
+      { x: 2, y: 0 },
+      { x: 0, y: 0 },
+    ],
+  };
+
   simulator.addZone({
     type: "zone",
     initialPosition: { x: 0, y: 0 },
     baseColor: 0xff0000,
     opacity: 0.4,
-    //rectangleZone: {xLength: 2, zLength: 1,},
-    //ellipseZone: {xRadius: 1, zRadius: 2,},
-    polygonZone: {
-      points: [
-        { x: 0, y: 2 },
-        { x: 2, y: 2 },
-        { x: 2, y: 0 },
-        { x: 0, y: 0 },
-      ],
-    },
+    zoneShape: polygonZone,
     zoneId: "test-zone",
   });
 

--- a/src/engine/objects/Zone.ts
+++ b/src/engine/objects/Zone.ts
@@ -83,8 +83,8 @@ export class Zone extends SimObject {
         spec.ellipseZone.zRadius
       );
     } else if (spec.polygonZone) {
-      let shapePoints = [];
-      let fixturePoints = [];
+      const shapePoints = [];
+      const fixturePoints = [];
 
       for (let i = 0; i < spec.polygonZone.points.length; i++) {
         const point = new THREE.Vector2(

--- a/src/engine/objects/Zone.ts
+++ b/src/engine/objects/Zone.ts
@@ -1,6 +1,11 @@
 import * as THREE from "three";
 import { BodyDef, FixtureDef, Vec2, Box, Polygon } from "planck-js";
-import { IZoneSpec } from "../specs/CoreSpecs";
+import {
+  IZoneSpec,
+  IRectangleZoneSpec,
+  IEllipseZoneSpec,
+  IPolygonZoneSpec,
+} from "../specs/CoreSpecs";
 import { SimObject } from "./SimObject";
 import { Vector2d } from "../SimTypes";
 import { IZoneFixtureUserData } from "../specs/UserDataSpecs";
@@ -49,20 +54,19 @@ export class Zone extends SimObject {
     let fixtureShape;
     let zoneMesh;
 
-    if (spec.rectangleZone) {
+    if (spec.zoneShape.type == "rectangle") {
+      const zoneShape = spec.zoneShape as IRectangleZoneSpec;
       const zoneGeom = new THREE.PlaneGeometry(
-        spec.rectangleZone.xLength,
-        spec.rectangleZone.zLength
+        zoneShape.xLength,
+        zoneShape.zLength
       );
       zoneMesh = new THREE.Mesh(zoneGeom, zoneMaterial);
 
-      fixtureShape = new Box(
-        spec.rectangleZone.xLength / 2,
-        spec.rectangleZone.zLength / 2
-      );
-    } else if (spec.ellipseZone) {
-      const xRadius = spec.ellipseZone.xRadius;
-      const yRadius = spec.ellipseZone.zRadius;
+      fixtureShape = new Box(zoneShape.xLength / 2, zoneShape.zLength / 2);
+    } else if (spec.zoneShape.type == "ellipse") {
+      const zoneShape = spec.zoneShape as IEllipseZoneSpec;
+      const xRadius = zoneShape.xRadius;
+      const yRadius = zoneShape.zRadius;
 
       const shape = new THREE.Shape().ellipse(
         initialPosition.x,
@@ -78,25 +82,20 @@ export class Zone extends SimObject {
       const zoneGeom = new THREE.ShapeBufferGeometry(shape);
       zoneMesh = new THREE.Mesh(zoneGeom, zoneMaterial);
 
-      fixtureShape = new Box(
-        spec.ellipseZone.xRadius,
-        spec.ellipseZone.zRadius
-      );
-    } else if (spec.polygonZone) {
+      fixtureShape = new Box(zoneShape.xRadius, zoneShape.zRadius);
+    } else if (spec.zoneShape.type == "polygon") {
+      const zoneShape = spec.zoneShape as IPolygonZoneSpec;
       const shapePoints = [];
       const fixturePoints = [];
 
-      for (let i = 0; i < spec.polygonZone.points.length; i++) {
+      for (let i = 0; i < zoneShape.points.length; i++) {
         const point = new THREE.Vector2(
-          spec.polygonZone.points[i].x,
-          spec.polygonZone.points[i].y
+          zoneShape.points[i].x,
+          zoneShape.points[i].y
         );
         shapePoints.push(point);
 
-        const fixPoint = new Vec2(
-          spec.polygonZone.points[i].x,
-          spec.polygonZone.points[i].y
-        );
+        const fixPoint = new Vec2(zoneShape.points[i].x, zoneShape.points[i].y);
         fixturePoints.push(fixPoint);
       }
 

--- a/src/engine/objects/Zone.ts
+++ b/src/engine/objects/Zone.ts
@@ -46,8 +46,8 @@ export class Zone extends SimObject {
 
     const zoneMaterial = new THREE.MeshBasicMaterial(materialSpecs);
 
-    var fixtureShape;
-    var zoneMesh;
+    let fixtureShape;
+    let zoneMesh;
 
     if (spec.rectangleZone) {
       const zoneGeom = new THREE.PlaneGeometry(
@@ -83,10 +83,10 @@ export class Zone extends SimObject {
         spec.ellipseZone.zRadius
       );
     } else if (spec.polygonZone) {
-      var shapePoints = [];
-      var fixturePoints = [];
+      let shapePoints = [];
+      let fixturePoints = [];
 
-      for (var i = 0; i < spec.polygonZone.points.length; i++) {
+      for (let i = 0; i < spec.polygonZone.points.length; i++) {
         const point = new THREE.Vector2(
           spec.polygonZone.points[i].x,
           spec.polygonZone.points[i].y

--- a/src/engine/objects/Zone.ts
+++ b/src/engine/objects/Zone.ts
@@ -61,10 +61,10 @@ export class Zone extends SimObject {
         spec.rectangleZone.zLength / 2
       );
     } else if (spec.ellipseZone) {
-      var xRadius = spec.ellipseZone.xRadius;
-      var yRadius = spec.ellipseZone.zRadius;
+      const xRadius = spec.ellipseZone.xRadius;
+      const yRadius = spec.ellipseZone.zRadius;
 
-      var shape = new THREE.Shape().ellipse(
+      const shape = new THREE.Shape().ellipse(
         initialPosition.x,
         initialPosition.y,
         xRadius,
@@ -75,7 +75,7 @@ export class Zone extends SimObject {
         0
       );
 
-      var zoneGeom = new THREE.ShapeBufferGeometry(shape);
+      const zoneGeom = new THREE.ShapeBufferGeometry(shape);
       zoneMesh = new THREE.Mesh(zoneGeom, zoneMaterial);
 
       fixtureShape = new Box(
@@ -87,21 +87,21 @@ export class Zone extends SimObject {
       var fixturePoints = [];
 
       for (var i = 0; i < spec.polygonZone.points.length; i++) {
-        var point = new THREE.Vector2(
+        const point = new THREE.Vector2(
           spec.polygonZone.points[i].x,
           spec.polygonZone.points[i].y
         );
         shapePoints.push(point);
 
-        var fixPoint = new Vec2(
+        const fixPoint = new Vec2(
           spec.polygonZone.points[i].x,
           spec.polygonZone.points[i].y
         );
         fixturePoints.push(fixPoint);
       }
 
-      var shape = new THREE.Shape(shapePoints);
-      var zoneGeom = new THREE.ShapeBufferGeometry(shape);
+      const shape = new THREE.Shape(shapePoints);
+      const zoneGeom = new THREE.ShapeBufferGeometry(shape);
       zoneMesh = new THREE.Mesh(zoneGeom, zoneMaterial);
 
       fixtureShape = new Polygon(fixturePoints);

--- a/src/engine/specs/CoreSpecs.ts
+++ b/src/engine/specs/CoreSpecs.ts
@@ -12,7 +12,8 @@ export type SimObjectSpec =
   | IPyramidSpec
   | IConeSpec
   | ICylinderSpec
-  | IZoneSpec;
+  | IZoneSpec
+  | IRectangleZoneSpec;
 
 export interface IPhysicsProperties {
   linearDamping?: number;
@@ -107,17 +108,24 @@ export interface ICustomMeshSpec {
   scale?: Vector3d;
 }
 
-export interface IRectangleZoneSpec {
+interface IBaseZoneShape {
+  type: string;
+}
+
+export interface IRectangleZoneSpec extends IBaseZoneShape {
+  type: "rectangle";
   xLength: number;
   zLength: number;
 }
 
-export interface IEllipseZoneSpec {
+export interface IEllipseZoneSpec extends IBaseZoneShape {
+  type: "ellipse";
   xRadius: number;
   zRadius: number;
 }
 
-export interface IPolygonZoneSpec {
+export interface IPolygonZoneSpec extends IBaseZoneShape {
+  type: "polygon";
   points: Vector2d[];
 }
 
@@ -125,9 +133,7 @@ export interface IPolygonZoneSpec {
 export interface IZoneSpec extends IBaseSimObjectSpec {
   type: "zone";
   zoneId: string;
-  rectangleZone?: IRectangleZoneSpec;
-  ellipseZone?: IEllipseZoneSpec;
-  polygonZone?: IPolygonZoneSpec;
+  zoneShape: IBaseZoneShape;
   opacity?: number;
 }
 

--- a/src/engine/specs/CoreSpecs.ts
+++ b/src/engine/specs/CoreSpecs.ts
@@ -107,12 +107,27 @@ export interface ICustomMeshSpec {
   scale?: Vector3d;
 }
 
+export interface IRectangleZoneSpec {
+  xLength: number;
+  zLength: number;
+}
+
+export interface IEllipseZoneSpec {
+  xRadius: number;
+  zRadius: number;
+}
+
+export interface IPolygonZoneSpec {
+  points: Vector2d[];
+}
+
 // Zone
 export interface IZoneSpec extends IBaseSimObjectSpec {
   type: "zone";
   zoneId: string;
-  xLength: number;
-  zLength: number;
+  rectangleZone?: IRectangleZoneSpec;
+  ellipseZone?: IEllipseZoneSpec;
+  polygonZone?: IPolygonZoneSpec;
   opacity?: number;
 }
 


### PR DESCRIPTION
Fixes #103

Some issues:

1. the polygon gets placed by the first point not by the center of the shape like the ellipse and the rectangle (because the center is unknown).
2. The ellipse's physics body is a circumscribing rectangle right now. We could try to approximate the ellipse with a polygon physics I suppose?
3. Wasn't sure if the spec needed to be backwards compatible with the previous rectangle-only format. I can make it so if necessary. 
4. I left all three ways to create the zone in the demo1.ts file with 2 of them commented out, just for examples and ease of testing.