### PR TITLE
add top and bottom sensors

### DIFF
--- a/src/engine/specs/RobotSpecs.ts
+++ b/src/engine/specs/RobotSpecs.ts
@@ -15,6 +15,8 @@ export enum SensorMountingFace {
   LEFT,
   RIGHT,
   REAR,
+  TOP,
+  BOTTOM,
 }
 
 export interface IRobotWheelSpec extends IBaseSimObjectSpec {

--- a/src/engine/utils/RobotUtils.ts
+++ b/src/engine/utils/RobotUtils.ts
@@ -14,7 +14,7 @@ export function getSensorMountPosition(
 
   let result: Vector3d = {
     x: initialPosition.x,
-    y: 0,
+    y: robotSpec.dimensions.y / 2,
     z: initialPosition.y,
   };
 
@@ -34,6 +34,12 @@ export function getSensorMountPosition(
       break;
     case SensorMountingFace.REAR:
       result.z += robotSpec.dimensions.z / 2;
+      break;
+    case SensorMountingFace.TOP:
+      result.y += robotSpec.dimensions.y / 2;
+      break;
+    case SensorMountingFace.BOTTOM:
+      result.y -= robotSpec.dimensions.y / 2;
       break;
   }
 


### PR DESCRIPTION
For #111

But I couldn't find where to make the sensors point a specific direction by default unless that's in the specific sensor classes. 

I did not add these types to the Contact sensor class or Distance sensor class because I wasn't sure what type of sensors these enums were intended for. 