### PR TITLE
Halt physics flag to disable physics processing

### DIFF
--- a/src/engine/Sim3D.ts
+++ b/src/engine/Sim3D.ts
@@ -73,7 +73,7 @@ export class Sim3D extends EventEmitter {
   private cameraManager: CameraManager;
 
   private isRendering = false;
-  private stopPhysics = false;
+  private physicsActive = true;
 
   private config: SimulatorConfig;
 
@@ -153,14 +153,14 @@ export class Sim3D extends EventEmitter {
       this.lastAnimateTime = time;
 
       window.requestAnimationFrame(r);
-      if (!this.stopPhysics) {
+      if (this.physicsActive) {
         this.updatePhysics(dt);
       }
       this.render(dt);
     };
 
     this.isRendering = true;
-    this.stopPhysics = true;
+    this.physicsActive = true;
 
     window.requestAnimationFrame(r);
   }
@@ -175,8 +175,8 @@ export class Sim3D extends EventEmitter {
   /**
    * Halt physics from re-processing, leaving rendering to continue
    */
-  haltPhysics(): void {
-    this.stopPhysics = true;
+  setPhysicsActive(isActive: boolean): void {
+    this.physicsActive = isActive;
   }
 
   // Public API - Objects

--- a/src/engine/Sim3D.ts
+++ b/src/engine/Sim3D.ts
@@ -73,6 +73,7 @@ export class Sim3D extends EventEmitter {
   private cameraManager: CameraManager;
 
   private isRendering = false;
+  private stopPhysics = false;
 
   private config: SimulatorConfig;
 
@@ -152,11 +153,15 @@ export class Sim3D extends EventEmitter {
       this.lastAnimateTime = time;
 
       window.requestAnimationFrame(r);
-      this.updatePhysics(dt);
+      if (!this.stopPhysics) {
+        this.updatePhysics(dt);
+      }
       this.render(dt);
     };
 
     this.isRendering = true;
+    this.stopPhysics = true;
+
     window.requestAnimationFrame(r);
   }
 
@@ -165,6 +170,13 @@ export class Sim3D extends EventEmitter {
    */
   stopRendering(): void {
     this.isRendering = false;
+  }
+
+  /**
+   * Halt physics from re-processing, leaving rendering to continue
+   */
+  haltPhysics(): void {
+    this.stopPhysics = true;
   }
 
   // Public API - Objects

--- a/src/engine/Sim3D.ts
+++ b/src/engine/Sim3D.ts
@@ -173,7 +173,7 @@ export class Sim3D extends EventEmitter {
   }
 
   /**
-   * Halt physics from re-processing, leaving rendering to continue
+   * Enable or disable simulator physics
    */
   setPhysicsActive(isActive: boolean): void {
     this.physicsActive = isActive;


### PR DESCRIPTION
Add halt physics flag, to stop physics steps executing whilst still rendering the canvas. This allows the camera to continue to be used after a program has finished execution