### PR TITLE
fix IColorSensorSpec mismatch

### DIFF
--- a/src/builder/RobotBuilder.ts
+++ b/src/builder/RobotBuilder.ts
@@ -459,7 +459,7 @@ export class ColorSensorBuilder implements IColorSensorSpec {
     return this._spec.render;
   }
 
-  get width(): number | undefined {
+  get width(): number {
     return this._spec.width;
   }
 


### PR DESCRIPTION
Fix to make ColorSensorBuilder match the IColorSensorSpec. This fix can also go the other direction probably.