### PR TITLE
Update to latest setup-node action version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v1.4.2
+        uses: actions/setup-node@v1.4.4
 
       - name: install
         run: npm install


### PR DESCRIPTION
### Description

setup-node 1.4.2 uses add-path. This is now deprecated. setup-node version 1.4.4 has been modified to not use it.

This PR fixes the publish action failing on master commits.