### PR TITLE
Invert prismatic joint direction

### DIFF
--- a/src/engine/objects/robot/mechanisms/SimGripperMechanism.ts
+++ b/src/engine/objects/robot/mechanisms/SimGripperMechanism.ts
@@ -217,8 +217,8 @@ export class SimGripperMechanism extends SimMechanism {
 
     const slideSpec = {
       enableLimit: true,
-      lowerTranslation: -this._width,
-      upperTranslation: 0,
+      upperTranslation: this._width,
+      lowerTranslation: 0,
       enableMotor: true,
       maxMotorForce: 1,
       motorSpeed: this._openSpeed,
@@ -229,7 +229,7 @@ export class SimGripperMechanism extends SimMechanism {
       this._body,
       slideJaw.body,
       slideJaw.body.getWorldCenter(),
-      new Vec2(1, 0)
+      new Vec2(-1, 0)
     );
 
     world.createJoint(this._slideJoint);


### PR DESCRIPTION
Fix for https://github.com/FRUK-Simulator/SimulatorCore/issues/131 - looks like the prismatic joint was just the wrong way round. Putting it the right way round stops the jaw from forcing itself open at the start, removing the consequent force on the robot