### PR TITLE
Fix distance sensors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruk/simulator-core",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "FIRST Robotics Simulator Core",
   "main": "dist/index.js",
   "scripts": {

--- a/src/engine/Sim3D.ts
+++ b/src/engine/Sim3D.ts
@@ -329,7 +329,9 @@ export class Sim3D extends EventEmitter {
     if (enabled) {
       this.fpsIndicator = document.body.appendChild(this.perfMonitor.dom);
     } else {
-      document.body.removeChild(this.fpsIndicator!);
+      if (this.fpsIndicator) {
+        document.body.removeChild(this.fpsIndicator);
+      }
       this.fpsIndicator = undefined;
     }
   }

--- a/src/engine/Sim3D.ts
+++ b/src/engine/Sim3D.ts
@@ -248,6 +248,8 @@ export class Sim3D extends EventEmitter {
    * @param spec Specification for a robot
    */
   addRobot(spec: IRobotSpec): RobotHandle | undefined {
+    console.info("Robot added", spec);
+
     const robot = new SimRobot(spec);
 
     const robotBody = this.world.createBody(robot.getBodySpecs());
@@ -292,6 +294,9 @@ export class Sim3D extends EventEmitter {
     }
 
     const handle = new RobotHandle(robot, robotRoot, this.handleRegistry);
+
+    console.debug("Robot", robot);
+    console.info("Robot handle", handle);
     return handle;
   }
 
@@ -572,7 +577,10 @@ export class Sim3D extends EventEmitter {
     this.simObjects.forEach((simObject) => {
       simObject.object.update(time);
     });
-    this.world.step(time, 10, 8);
+
+    // Timestep is set to constsant to avoid large jumps
+    // wreaking havok in the world.
+    this.world.step(1 / 60, 10, 8);
     this.world.clearForces();
   }
 

--- a/src/engine/objects/SimWall.ts
+++ b/src/engine/objects/SimWall.ts
@@ -88,7 +88,7 @@ export class SimWall extends SimObject {
     };
 
     // Add user data to aid debugging.
-    let userData: IBaseFixtureUserData = {
+    const userData: IBaseFixtureUserData = {
       selfGuid: this.guid,
       type: "wall",
     };

--- a/src/engine/objects/SimWall.ts
+++ b/src/engine/objects/SimWall.ts
@@ -11,6 +11,7 @@ import { IWallSpec } from "../specs/CoreSpecs";
 import { FixtureDef } from "planck-js";
 import { BodyDef } from "planck-js";
 import { EntityCategory, EntityMask } from "./robot/RobotCollisionConstants";
+import { IBaseFixtureUserData } from "../specs/UserDataSpecs";
 
 export const DEFAULT_WALL_THICKNESS = 0.1;
 export const DEFAULT_WALL_HEIGHT = 1;
@@ -86,12 +87,19 @@ export class SimWall extends SimObject {
       position: new Vec2(wallMidpoint.x, wallMidpoint.y),
     };
 
+    // Add user data to aid debugging.
+    let userData: IBaseFixtureUserData = {
+      selfGuid: this.guid,
+      type: "wall",
+    };
+
     this.fixtureSpecs = {
       shape: new Box(wallLength / 2, wallThickness / 2),
       density: 1,
       isSensor: false,
       filterCategoryBits: EntityCategory.WALL,
       filterMaskBits: EntityMask.WALL,
+      userData,
     };
   }
 

--- a/src/engine/objects/robot/SimRobot.ts
+++ b/src/engine/objects/robot/SimRobot.ts
@@ -46,6 +46,8 @@ export class SimRobot extends SimObject {
   private _meshLoader: GLTFLoader | undefined;
   private _usingCustomMesh = false;
 
+  private _debug_io: boolean = false;
+
   constructor(spec: IRobotSpec) {
     super("SimRobot");
 
@@ -313,7 +315,13 @@ export class SimRobot extends SimObject {
   }
 
   getAnalogInput(channel: number): number {
-    return this._basicSensors.getAnalogInput(channel);
+    let value = this._basicSensors.getAnalogInput(channel);
+
+    if (this._debug_io) {
+      console.debug("getAnalogInput", channel, value);
+    }
+
+    return value;
   }
 
   setDigitalOutput(channel: number, value: boolean): void {

--- a/src/engine/objects/robot/SimRobot.ts
+++ b/src/engine/objects/robot/SimRobot.ts
@@ -46,7 +46,7 @@ export class SimRobot extends SimObject {
   private _meshLoader: GLTFLoader | undefined;
   private _usingCustomMesh = false;
 
-  private _debug_io: boolean = false;
+  private _debug_io = false;
 
   constructor(spec: IRobotSpec) {
     super("SimRobot");
@@ -315,7 +315,7 @@ export class SimRobot extends SimObject {
   }
 
   getAnalogInput(channel: number): number {
-    let value = this._basicSensors.getAnalogInput(channel);
+    const value = this._basicSensors.getAnalogInput(channel);
 
     if (this._debug_io) {
       console.debug("getAnalogInput", channel, value);

--- a/src/engine/objects/robot/sensors/SimDistanceSensor.ts
+++ b/src/engine/objects/robot/sensors/SimDistanceSensor.ts
@@ -7,10 +7,7 @@ import {
   IBasicSensorValue,
   SensorMountingFace,
 } from "../../../specs/RobotSpecs";
-import {
-  ISensorFixtureUserData,
-  IBaseFixtureUserData,
-} from "../../../specs/UserDataSpecs";
+import { ISensorFixtureUserData } from "../../../specs/UserDataSpecs";
 import { getSensorMountPosition } from "../../../utils/RobotUtils";
 import { Vec2, Box, Fixture } from "planck-js";
 import { EntityCategory, EntityMask } from "../RobotCollisionConstants";
@@ -187,7 +184,16 @@ export class SimDistanceSensor extends SimBasicSensor {
           // Set the result to be the current reading
           result = fraction * detectionRange;
 
-          return fraction;
+          // TODO(jp) add debug mode to sensors.
+          if (false) {
+            console.debug(
+              "Ray cast hit object",
+              fixture.getUserData(),
+              p1,
+              p2,
+              p
+            );
+          }
         }
       );
 

--- a/src/engine/objects/robot/sensors/SimDistanceSensor.ts
+++ b/src/engine/objects/robot/sensors/SimDistanceSensor.ts
@@ -180,6 +180,7 @@ export class SimDistanceSensor extends SimBasicSensor {
           result = fraction * detectionRange;
 
           // TODO(jp) add debug mode to sensors.
+          // eslint-disable-next-line no-constant-condition
           if (false) {
             console.debug(
               "Ray cast hit object",

--- a/src/engine/objects/robot/sensors/SimDistanceSensor.ts
+++ b/src/engine/objects/robot/sensors/SimDistanceSensor.ts
@@ -170,15 +170,10 @@ export class SimDistanceSensor extends SimBasicSensor {
         p1,
         p2,
         (fixture: Fixture, p: Vec2, normal: Vec2, fraction: number): number => {
-          // Ignore everything that is part of the robot that this sensor is attached to
-          if (fixture.getUserData()) {
-            const userData = fixture.getUserData() as IBaseFixtureUserData;
-            if (
-              userData.rootGuid === this._robotGuid ||
-              userData.selfGuid === this._robotGuid
-            ) {
-              return -1;
-            }
+          //Distance sensor rays collide with things the robot collides with...
+          if (!(fixture.m_filterCategoryBits & EntityMask.SENSORS)) {
+            // by returning -1 we ignore this collision and continue.
+            return -1;
           }
 
           // Set the result to be the current reading
@@ -194,6 +189,9 @@ export class SimDistanceSensor extends SimBasicSensor {
               p
             );
           }
+
+          // by returning 0 we end the raycast.
+          return 0.0;
         }
       );
 


### PR DESCRIPTION
The distance sensors were sensing things like zones and other things in the scene.

This pr changes the way the filtering works in the ray casting process. Now the objects categories and masks are used to filter the fixtures in the ray's path.