### PR TITLE
Increase the robot mass to make the simulator easier to use

### DIFF
--- a/src/demos/demo1.ts
+++ b/src/demos/demo1.ts
@@ -385,8 +385,8 @@ function main() {
         console.log("Release Grabber");
         robot.setDigitalOutput(gripperGrabChannel, false);
         // move forward slowly
-        robot.setMotorPower(0, 0.05);
-        robot.setMotorPower(1, 0.05);
+        robot.setMotorPower(0, 0.3);
+        robot.setMotorPower(1, 0.3);
         break;
       case RobotMode.GRABBING:
         // trigger grabbing to start
@@ -398,13 +398,13 @@ function main() {
         break;
       case RobotMode.CELEBRATE:
         // set motors to fast spin
-        robot.setMotorPower(0, -0.5);
-        robot.setMotorPower(1, 0.5);
+        robot.setMotorPower(0, -0.7);
+        robot.setMotorPower(1, 0.7);
         break;
       case RobotMode.SHAME:
         // set motors to slow spin
-        robot.setMotorPower(0, 0.1);
-        robot.setMotorPower(1, -0.1);
+        robot.setMotorPower(0, 0.3);
+        robot.setMotorPower(1, -0.3);
         break;
     }
 

--- a/src/engine/objects/robot/SimRobot.ts
+++ b/src/engine/objects/robot/SimRobot.ts
@@ -131,7 +131,7 @@ export class SimRobot extends SimObject {
 
     this._fixtureSpecs = {
       shape: new Box(spec.dimensions.x / 2, spec.dimensions.z / 2),
-      density: 1,
+      density: 7,
       isSensor: false,
       friction: 0.3,
       restitution: 0.4,


### PR DESCRIPTION
Currently the robot is very lightweight compared to the motor powers we apply to it in the Simulator and that makes it tricky to program the robot. See https://github.com/FRUK-Simulator/Simulator/issues/151 One can check the current mass of the robot by adding some logging to `Sim3D`'s `addRobot` method:

```js
console.info(`Robot mass: ${robotBody.getMass()}`);
```

which shows "Robot mass: 0.057". I believe the unit here is kg,  based on https://box2d.org/documentation/index.html#autotoc_md17

`Box2D`, and `planck.js`, derive the robot mass from the shape of a body and its density. To make the robot a bit heavier I therefore increased the robot fixture density, which I believe is the recommended way to achieve this, according to https://box2d.org/documentation/md__d_1__git_hub_box2d_docs_dynamics.html#autotoc_md76