### PR TITLE
add user supplied object ids to events

### DIFF
--- a/src/builder/RobotBuilder.ts
+++ b/src/builder/RobotBuilder.ts
@@ -109,6 +109,11 @@ export class Builder {
     return this;
   }
 
+  setId(id: string): Builder {
+    this._spec.id = id;
+    return this;
+  }
+
   generateSpec(): IRobotSpec {
     return this._spec;
   }

--- a/src/demos/demo2.ts
+++ b/src/demos/demo2.ts
@@ -44,7 +44,7 @@ function main() {
   simulator.setDebugMode(debug_mode_default);
 
   gui = new GUI();
-  (window as any).gui = gui;
+  (window as any).gui = gui; // eslint-disable-line @typescript-eslint/no-explicit-any
   const debugFolder = gui.addFolder("Debug Options");
   const debugModeController = debugFolder
     .add(demoOptions, "debugMode")

--- a/src/demos/demo3.ts
+++ b/src/demos/demo3.ts
@@ -1,7 +1,6 @@
 import { Sim3D, SimulatorConfig, RobotSpecs, RobotBuilder } from "../index";
 import { GUI } from "dat.gui";
 import { RobotHandle } from "../engine/handles";
-import { ZeroSlopeEnding } from "three";
 import { ISimulatorEvent } from "../engine/specs/CoreSpecs";
 
 let gui: GUI;
@@ -56,7 +55,7 @@ function main() {
   simulator.setDebugMode(debug_mode_default);
 
   gui = new GUI();
-  (window as any).gui = gui;
+  (window as any).gui = gui; // eslint-disable-line @typescript-eslint/no-explicit-any
   const debugFolder = gui.addFolder("Debug Options");
   const debugModeController = debugFolder
     .add(demoOptions, "debugMode")
@@ -161,13 +160,13 @@ function main() {
     },
   });
 
-  let el = window.document.body;
+  const el = window.document.body;
 
   el.addEventListener("keydown", keyListener);
   el.addEventListener("keyup", keyListener);
 
-  let eventListEl = window.document.createElement("ol");
-  let clearEl = window.document.createElement("button");
+  const eventListEl = window.document.createElement("ol");
+  const clearEl = window.document.createElement("button");
 
   el.appendChild(eventListEl);
   el.appendChild(clearEl);
@@ -182,10 +181,10 @@ function main() {
   });
 
   simulator.addListener("simulation-event", (e) => {
-    let event = e as ISimulatorEvent;
-    let eventEl = window.document.createElement("li");
+    const event = e as ISimulatorEvent;
+    const eventEl = window.document.createElement("li");
     eventEl.innerText = JSON.stringify(event.data);
-    let eventTypeEl = window.document.createElement("i");
+    const eventTypeEl = window.document.createElement("i");
     eventTypeEl.innerText = event.type;
     eventEl.prepend(eventTypeEl);
     eventListEl.appendChild(eventEl);
@@ -205,7 +204,7 @@ enum Direction {
 
 function keyListener(this: HTMLElement, e: KeyboardEvent) {
   console.assert(e.type === "keydown" || e.type == "keyup");
-  let isDown = e.type == "keydown";
+  const isDown = e.type == "keydown";
 
   let drive: Drive = null;
   let direction: Direction = null;

--- a/src/demos/demo3.ts
+++ b/src/demos/demo3.ts
@@ -79,6 +79,7 @@ function main() {
     .setMaxForce(1);
 
   robotBuilder
+    .setId("robo")
     .setDimensions({ x: 0.225, y: 0.125, z: 0.255 })
     .addWheel("left-drive", wheel)
     .addWheel(
@@ -183,7 +184,10 @@ function main() {
   simulator.addListener("simulation-event", (e) => {
     let event = e as ISimulatorEvent;
     let eventEl = window.document.createElement("li");
-    eventEl.innerText = JSON.stringify(e);
+    eventEl.innerText = JSON.stringify(event.data);
+    let eventTypeEl = window.document.createElement("i");
+    eventTypeEl.innerText = event.type;
+    eventEl.prepend(eventTypeEl);
     eventListEl.appendChild(eventEl);
   });
 }

--- a/src/engine/EventRegistry.ts
+++ b/src/engine/EventRegistry.ts
@@ -218,7 +218,7 @@ export class EventRegistry extends EventEmitter {
         return;
       }
       // A is the zone
-      zoneId = userDataA.zone.id;
+      zoneId = userDataA.id;
 
       if (userDataB.rootGuid !== undefined) {
         objectGuid = userDataB.rootGuid;
@@ -230,7 +230,7 @@ export class EventRegistry extends EventEmitter {
         return;
       }
       // B is the zone
-      zoneId = userDataB.zone.id;
+      zoneId = userDataB.id;
 
       if (userDataA.rootGuid !== undefined) {
         objectGuid = userDataA.rootGuid;

--- a/src/engine/Sim3D.ts
+++ b/src/engine/Sim3D.ts
@@ -43,6 +43,7 @@ import Stats from "stats.js";
 interface ISimObjectContainer {
   type: string;
   object: SimObject;
+  id?: string;
 }
 
 const DEFAULT_CONFIG: SimulatorConfig = {
@@ -286,6 +287,7 @@ export class Sim3D extends EventEmitter {
     this.addToScene(robot);
     this.simObjects.set(robot.guid, {
       type: robot.type,
+      id: spec.id,
       object: robot,
     });
 
@@ -451,6 +453,7 @@ export class Sim3D extends EventEmitter {
         {
           zoneId: data.zoneId,
           objectRef: objRef,
+          objectId: data.objectId,
         },
         objRef
       );
@@ -674,6 +677,7 @@ export class Sim3D extends EventEmitter {
     this.simObjects.set(obj.guid, {
       type: obj.type,
       object: obj,
+      id: spec.id,
     });
 
     const simObjectRef = {
@@ -730,6 +734,7 @@ export class Sim3D extends EventEmitter {
     const obj = this.simObjects.get(objectGuid);
     return {
       guid: objectGuid,
+      id: obj.id,
       type: obj.type,
     };
   }

--- a/src/engine/SimTypes.ts
+++ b/src/engine/SimTypes.ts
@@ -20,4 +20,5 @@ export type Vector2d = {
 export interface ISimObjectRef {
   guid: string;
   type: string;
+  id?: string;
 }

--- a/src/engine/objects/SimBall.ts
+++ b/src/engine/objects/SimBall.ts
@@ -59,6 +59,7 @@ export class SimBall extends SimObject {
     const userData: IBaseFixtureUserData = {
       selfGuid: this.guid,
       type: "simobject-ball",
+      id: spec.id,
     };
 
     this.fixtureSpecs = {

--- a/src/engine/objects/SimBox.ts
+++ b/src/engine/objects/SimBox.ts
@@ -61,6 +61,7 @@ export class SimBox extends SimObject {
     const userData: IBaseFixtureUserData = {
       selfGuid: this.guid,
       type: "simobject-box",
+      id: spec.id,
     };
 
     this.fixtureSpecs = {

--- a/src/engine/objects/SimCone.ts
+++ b/src/engine/objects/SimCone.ts
@@ -59,6 +59,7 @@ export class SimCone extends SimObject {
     const userData: IBaseFixtureUserData = {
       selfGuid: this.guid,
       type: "simobject-cone",
+      id: spec.id,
     };
 
     this.fixtureSpecs = {

--- a/src/engine/objects/SimCylinder.ts
+++ b/src/engine/objects/SimCylinder.ts
@@ -63,6 +63,7 @@ export class SimCylinder extends SimObject {
     const userData: IBaseFixtureUserData = {
       selfGuid: this.guid,
       type: "simobject-cylinder",
+      id: spec.id,
     };
 
     this.fixtureSpecs = {

--- a/src/engine/objects/SimWall.ts
+++ b/src/engine/objects/SimWall.ts
@@ -91,6 +91,7 @@ export class SimWall extends SimObject {
     const userData: IBaseFixtureUserData = {
       selfGuid: this.guid,
       type: "wall",
+      id: spec.id,
     };
 
     this.fixtureSpecs = {

--- a/src/engine/objects/Zone.ts
+++ b/src/engine/objects/Zone.ts
@@ -128,8 +128,8 @@ export class Zone extends SimObject {
     const userData: IZoneFixtureUserData = {
       selfGuid: this.guid,
       type: "zone",
+      id: this._zoneId,
       zone: {
-        id: this._zoneId,
         color: spec.baseColor,
       },
     };

--- a/src/engine/objects/robot/SimRobot.ts
+++ b/src/engine/objects/robot/SimRobot.ts
@@ -127,6 +127,7 @@ export class SimRobot extends SimObject {
     const userData: IBaseFixtureUserData = {
       selfGuid: this.guid,
       type: "robot",
+      id: spec.id,
     };
 
     this._fixtureSpecs = {

--- a/src/engine/objects/robot/SimRobotWheel.ts
+++ b/src/engine/objects/robot/SimRobotWheel.ts
@@ -80,6 +80,7 @@ export class SimRobotWheel extends SimObject {
       selfGuid: this.guid,
       rootGuid: robotGuid,
       type: "wheel",
+      id: spec.id,
     };
 
     this._fixtureSpecs = {

--- a/src/engine/specs/CoreSpecs.ts
+++ b/src/engine/specs/CoreSpecs.ts
@@ -35,6 +35,8 @@ export interface IBaseSimObjectSpec {
   initialPosition?: Vector2d;
   physicsProperties?: IPhysicsProperties;
   baseColor?: number;
+  /** User provided string used to correlate events */
+  id?: string;
 }
 
 /**
@@ -142,6 +144,7 @@ export interface IZoneSpec extends IBaseSimObjectSpec {
 export interface IRawZoneEvent {
   zoneId: string;
   objectGuid: string;
+  objectId: string;
 }
 
 /**

--- a/src/engine/specs/CoreSpecs.ts
+++ b/src/engine/specs/CoreSpecs.ts
@@ -12,8 +12,7 @@ export type SimObjectSpec =
   | IPyramidSpec
   | IConeSpec
   | ICylinderSpec
-  | IZoneSpec
-  | IRectangleZoneSpec;
+  | IZoneSpec;
 
 export interface IPhysicsProperties {
   linearDamping?: number;

--- a/src/engine/specs/UserDataSpecs.ts
+++ b/src/engine/specs/UserDataSpecs.ts
@@ -7,6 +7,7 @@ export interface IBaseFixtureUserData {
   selfGuid: string; // The GUID of the SimObject this fixture belongs to
   rootGuid?: string; // (optional) GUID of the top-level SimObject
   type: string;
+  id?: string; // (optional) user defined identifier for object
 }
 
 export interface ISensorFixtureUserData extends IBaseFixtureUserData {
@@ -17,7 +18,6 @@ export interface ISensorFixtureUserData extends IBaseFixtureUserData {
 export interface IZoneFixtureUserData extends IBaseFixtureUserData {
   type: "zone";
   zone: {
-    id: string;
     color?: number;
   };
 }


### PR DESCRIPTION
This will allow the user of SimulatorCore to differentiate between different objects

There does already exist a unique guid for each object, but since this is generated inside SimulatorCore the users of this project can't use this themselves.