### PR TITLE
Support adding walls in the middle of the map

### DIFF
--- a/src/engine/Sim3D.ts
+++ b/src/engine/Sim3D.ts
@@ -546,10 +546,18 @@ export class Sim3D extends EventEmitter {
     );
     this.scene.add(grid);
 
-    const walls = wallSpecs(worldConfig);
+    const perimeterWalls = wallSpecs(worldConfig);
 
-    for (const spec of walls) {
+    // Add perimeter walls
+    for (const spec of perimeterWalls) {
       this.addWall(spec);
+    }
+
+    // Add obstacle walls in the map
+    if (worldConfig.walls) {
+      for (const wall of worldConfig.walls) {
+        this.addWall(wall);
+      }
     }
 
     // Axes


### PR DESCRIPTION
Currently, `WorldConfig.perimeter` deprecates the `WorldConfig.walls`. 
However, in need of the obstacle wall as described in https://github.com/FRUK-Simulator/Simulator/issues/204, we need to keep the use of `WorldConfig.walls`. This PR is to re-enable `WorldConfig.walls` so that we can put walls anywhere on the map.