### PR TITLE
Downgrade ThreeJS to 0.136

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@fruk/simulator-core",
-  "version": "1.8.0",
+  "version": "1.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fruk/simulator-core",
-      "version": "1.8.0",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
-        "@types/three": "^0.127.1",
+        "@types/three": "^0.136.0",
         "planck-js": "^0.3.29",
         "stats.js": "^0.17.0",
-        "three": "^0.137.0",
+        "three": "^0.136.0",
         "uuid": "^8.3.0"
       },
       "devDependencies": {
@@ -1986,9 +1986,9 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.127.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.127.1.tgz",
-      "integrity": "sha512-e90iYq3zde3axANg7BPZY0fKrez1AzveamIIFk23PMh9WtCx91geokDy+yEAIymdIldgUpvezAP6+zCV3oekXw=="
+      "version": "0.136.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.136.1.tgz",
+      "integrity": "sha512-gzTw6RR4dU8sGf+RpLBWWKHRVIJ4gwKVQPk+IFCgha04Efg/itXYUalX6iBcYeSmaDu0qE5M7uTq0XLQpU4FAg=="
     },
     "node_modules/@types/uglify-js": {
       "version": "3.9.3",
@@ -15226,9 +15226,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.137.0.tgz",
-      "integrity": "sha512-rzSDhia6cU35UCy6y+zEEws6vSgytfHqFMSaBvUcySgzwvDO6vETyswtSNi/+aVqJw8WLMwyT1mlQQ1T/dxxOA=="
+      "version": "0.136.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.136.0.tgz",
+      "integrity": "sha512-+fEMX7nYLz2ZesVP/dyifli5Jf8gR3XPAnFJveQ80aMhibFduzrADnjMbARXh8+W9qLK7rshJCjAIL/6cDxC+A=="
     },
     "node_modules/throat": {
       "version": "5.0.0",
@@ -18988,9 +18988,9 @@
       "dev": true
     },
     "@types/three": {
-      "version": "0.127.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.127.1.tgz",
-      "integrity": "sha512-e90iYq3zde3axANg7BPZY0fKrez1AzveamIIFk23PMh9WtCx91geokDy+yEAIymdIldgUpvezAP6+zCV3oekXw=="
+      "version": "0.136.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.136.1.tgz",
+      "integrity": "sha512-gzTw6RR4dU8sGf+RpLBWWKHRVIJ4gwKVQPk+IFCgha04Efg/itXYUalX6iBcYeSmaDu0qE5M7uTq0XLQpU4FAg=="
     },
     "@types/uglify-js": {
       "version": "3.9.3",
@@ -29457,9 +29457,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.137.0.tgz",
-      "integrity": "sha512-rzSDhia6cU35UCy6y+zEEws6vSgytfHqFMSaBvUcySgzwvDO6vETyswtSNi/+aVqJw8WLMwyT1mlQQ1T/dxxOA=="
+      "version": "0.136.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.136.0.tgz",
+      "integrity": "sha512-+fEMX7nYLz2ZesVP/dyifli5Jf8gR3XPAnFJveQ80aMhibFduzrADnjMbARXh8+W9qLK7rshJCjAIL/6cDxC+A=="
     },
     "throat": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruk/simulator-core",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "FIRST Robotics Simulator Core",
   "main": "dist/index.js",
   "scripts": {
@@ -26,10 +26,10 @@
   },
   "homepage": "https://github.com/FRUK-Simulator/SimulatorCore#readme",
   "dependencies": {
-    "@types/three": "^0.127.1",
+    "@types/three": "^0.136.0",
     "planck-js": "^0.3.29",
     "stats.js": "^0.17.0",
-    "three": "^0.137.0",
+    "three": "^0.136.0",
     "uuid": "^8.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Version 0.137 of ThreeJS has new packaging or loading requirement that broke the simulator.
This change downgrade the version to 0.136 until we'll fix the simulator to properly use newer version.