### PR TITLE
Fix initial position of polygons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fruk/simulator-core",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "FIRST Robotics Simulator Core",
   "main": "dist/index.js",
   "scripts": {

--- a/src/engine/objects/Zone.ts
+++ b/src/engine/objects/Zone.ts
@@ -93,10 +93,7 @@ export class Zone extends SimObject {
 
       // We need to transform the zone's Vector2d points into THREE.Vector2 points.
       zoneShape.points.forEach((vector2dPoint) => {
-        const point = new THREE.Vector2(
-          vector2dPoint.x + initialPosition.x,
-          vector2dPoint.y + initialPosition.y
-        );
+        const point = new THREE.Vector2(vector2dPoint.x, vector2dPoint.y);
         shapePoints.push(point);
       });
 


### PR DESCRIPTION
We realised we were adding the `initialPosition` twice.