### PR TITLE
Add getting motor input signal

### DIFF
--- a/src/engine/handles/RobotHandle.ts
+++ b/src/engine/handles/RobotHandle.ts
@@ -6,6 +6,10 @@ export class RobotHandle extends ObjectHandle<SimRobot> {
     this._rootObject.setMotorPower(channel, value);
   }
 
+  getMotorInputSignal(channel: number): number {
+    return this._rootObject.getMotorInputSignal(channel);
+  }
+
   getDigitalInput(channel: number): boolean {
     return this._rootObject.getDigitalInput(channel);
   }

--- a/src/engine/objects/robot/SimRobot.ts
+++ b/src/engine/objects/robot/SimRobot.ts
@@ -311,6 +311,10 @@ export class SimRobot extends SimObject {
     this._drivetrain.setMotorPower(channel, value);
   }
 
+  getMotorInputSignal(channel: number): number {
+    return this._drivetrain.getMotorInputSignal(channel);
+  }
+
   getDigitalInput(channel: number): boolean {
     return this._basicSensors.getDigitalInput(channel);
   }

--- a/src/engine/objects/robot/SimRobotDrivetrain.ts
+++ b/src/engine/objects/robot/SimRobotDrivetrain.ts
@@ -192,6 +192,11 @@ export class SimRobotDrivetrain {
     motor.inputSignal = value;
   }
 
+  getMotorInputSignal(channel: number): number {
+    const motor = this._motors.get(channel);
+    return motor.inputSignal;
+  }
+
   update(): void {
     // Run through the list of wheel groups, get the power for each
     // wheel and assign it to the SimWheel


### PR DESCRIPTION
This is part of reworking RobotView.
This adds the ability to get from the robo the motor input signal to show in the RoboView.

See https://github.com/FRUK-Simulator/Simulator/pull/259 for more details how this change will be used.